### PR TITLE
Fix CLI typo and remove unused import

### DIFF
--- a/src/cli/asset_platforms.rs
+++ b/src/cli/asset_platforms.rs
@@ -26,14 +26,14 @@ pub struct ListCtx {
 impl ListCtx {
     pub async fn run_command(&self, client: &CoinGecko) -> Result<()> {
         println!("List...");
-        let respoinse = client
+        let response = client
             .asset_platforms()
             .list(AssetPlatformsListParts::None)
             .filter(self.only_nft_support)
             .send()
             .await?;
 
-        let body: Value = respoinse.json().await?;
+        let body: Value = response.json().await?;
         println!("{:#}", body);
         Ok(())
     }

--- a/src/cli/simple.rs
+++ b/src/cli/simple.rs
@@ -1,4 +1,4 @@
-use crate::api::{client::CoinGecko, response};
+use crate::api::client::CoinGecko;
 use crate::api::simple::{SimpleSupportedVsCurrenciesParts, SimpleTokenPriceParts};
 use anyhow::Result;
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
## Summary
- fix variable name typo in asset_platforms CLI
- remove unused import from simple CLI

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684020fd5a6c83259b8c7c59b906c2f9