### PR TITLE
Fix CLI typo and remove unused import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to CoinGecko-CLI
 
-Thank you for your interest in contributing to CoinGecko-CLI! We welcome contributions from the community to help improve our project. This document outlines the guidelines and steps for contributing to te project.
+Thank you for your interest in contributing to CoinGecko-CLI! We welcome contributions from the community to help improve our project. This document outlines the guidelines and steps for contributing to the project.
 
 ## Table of Contents
 - [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CoinGecko CLI
 
-In this project, we will be implementing a CLI that maps to CoingGecko API
+In this project, we will be implementing a CLI that maps to CoinGecko API
 https://www.coingecko.com/en/api/documentation#
 
 | Command         | Status      |

--- a/src/cli/asset_platforms.rs
+++ b/src/cli/asset_platforms.rs
@@ -26,14 +26,14 @@ pub struct ListCtx {
 impl ListCtx {
     pub async fn run_command(&self, client: &CoinGecko) -> Result<()> {
         println!("List...");
-        let respoinse = client
+        let response = client
             .asset_platforms()
             .list(AssetPlatformsListParts::None)
             .filter(self.only_nft_support)
             .send()
             .await?;
 
-        let body: Value = respoinse.json().await?;
+        let body: Value = response.json().await?;
         println!("{:#}", body);
         Ok(())
     }

--- a/src/cli/simple.rs
+++ b/src/cli/simple.rs
@@ -1,4 +1,4 @@
-use crate::api::{client::CoinGecko, response};
+use crate::api::client::CoinGecko;
 use crate::api::simple::{SimpleSupportedVsCurrenciesParts, SimpleTokenPriceParts};
 use anyhow::Result;
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
## Summary
- fix variable name typo in asset_platforms CLI
- remove unused import from simple CLI
- fix doc typos

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684020fd5a6c83259b8c7c59b906c2f9